### PR TITLE
토론 예약시 지속시간 정하는 기능 추가

### DIFF
--- a/Discussion-Korea/Discussion-Korea/AddReservationScene/AddReservationViewController.swift
+++ b/Discussion-Korea/Discussion-Korea/AddReservationScene/AddReservationViewController.swift
@@ -11,10 +11,14 @@ final class AddReservationViewController: UIViewController {
 
     @IBOutlet private weak var submitButton: UIBarButtonItem!
     @IBOutlet private weak var topicTextField: UITextField!
-    @IBOutlet private weak var durationLabel: UILabel!
+    @IBOutlet private weak var introTimeLabel: UILabel!
+    @IBOutlet private weak var mainTimeLabel: UILabel!
+    @IBOutlet private weak var conclusionTimeLabel: UILabel!
     @IBOutlet private weak var datePicker: UIDatePicker!
 
-    private var duration: Int = 1
+    private var introDuration: Int = 1
+    private var mainDuration: Int = 1
+    private var conclusionDuration: Int = 1
 
     private let repository: MessageRepository = DefaultMessageRepository(
         roomID: "1"
@@ -35,9 +39,19 @@ final class AddReservationViewController: UIViewController {
         self.view.endEditing(true)
     }
 
-    @IBAction func stepperValueChanged(_ sender: UIStepper) {
-        self.duration = Int(sender.value)
-        self.durationLabel.text = String(Int(sender.value))
+    @IBAction func introStepperValueChanged(_ sender: UIStepper) {
+        self.introDuration = Int(sender.value)
+        self.introTimeLabel.text = String(Int(sender.value))
+    }
+
+    @IBAction func mainStepperValueChanged(_ sender: UIStepper) {
+        self.mainDuration = Int(sender.value)
+        self.mainTimeLabel.text = String(Int(sender.value))
+    }
+
+    @IBAction func conclusionStepperValueChanged(_ sender: UIStepper) {
+        self.conclusionDuration = Int(sender.value)
+        self.conclusionTimeLabel.text = String(Int(sender.value))
     }
 
     @IBAction func submitButtonTouched(_ sender: UIBarButtonItem) {
@@ -45,10 +59,11 @@ final class AddReservationViewController: UIViewController {
               !topic.isEmpty
         else { return }
         let date = self.datePicker.date
-        let duration = self.duration
         let schedule = DisscussionSchedule(ID: "",
                                            date: date,
-                                           duration: duration,
+                                           introduction: self.introDuration,
+                                           main: self.mainDuration,
+                                           conclusion: self.conclusionDuration,
                                            topic: topic)
         self.repository.addSchedule(schedule)
         self.navigationController?.popViewController(animated: true)

--- a/Discussion-Korea/Discussion-Korea/ChatRoomScene/MessageRepository.swift
+++ b/Discussion-Korea/Discussion-Korea/ChatRoomScene/MessageRepository.swift
@@ -69,8 +69,8 @@ class DefaultMessageRepository: MessageRepository {
 
     init(roomID: String) {
         let roomReference: DatabaseReference = Database
-            .database(url: "http://localhost:9000?ns=test-3dbd4-default-rtdb")
-//            .database(url: "https://test-3dbd4-default-rtdb.asia-southeast1.firebasedatabase.app")
+//            .database(url: "http://localhost:9000?ns=test-3dbd4-default-rtdb")
+            .database(url: "https://test-3dbd4-default-rtdb.asia-southeast1.firebasedatabase.app")
             .reference()
             .child("chatRoom")
             .child(roomID)
@@ -187,11 +187,13 @@ class DefaultMessageRepository: MessageRepository {
             guard let dic = snapshot.value as? NSDictionary,
                   let dateString = dic["date"] as? String,
                   let date = self?.dateFormatter.date(from: dateString),
-                  let duration = dic["duration"] as? Int,
+                  let introduction = dic["introduction"] as? Int,
+                  let main = dic["main"] as? Int,
+                  let conclusion = dic["conclusion"] as? Int,
                   let topic = dic["topic"] as? String
             else { return }
             let scheduleID = snapshot.key
-            self?.schedulePublisher.send(DisscussionSchedule(ID: scheduleID, date: date, duration: duration, topic: topic))
+            self?.schedulePublisher.send(DisscussionSchedule(ID: scheduleID, date: date, introduction: introduction, main: main, conclusion: conclusion, topic: topic))
         }
         return self.schedulePublisher.eraseToAnyPublisher()
     }
@@ -255,7 +257,9 @@ class DefaultMessageRepository: MessageRepository {
 
     func addSchedule(_ schedule: DisscussionSchedule) {
         let value: [String: Any] = ["date": self.dateFormatter.string(from: schedule.date),
-                                    "duration": schedule.duration,
+                                    "introduction": schedule.introduction,
+                                    "main": schedule.main,
+                                    "conclusion": schedule.conclusion,
                                     "topic": schedule.topic]
         self.schedulesReferece.childByAutoId().setValue(value)
     }

--- a/Discussion-Korea/Discussion-Korea/DisscussionReservationScene/DisscussionReservationViewController.swift
+++ b/Discussion-Korea/Discussion-Korea/DisscussionReservationScene/DisscussionReservationViewController.swift
@@ -12,7 +12,9 @@ struct DisscussionSchedule {
 
     var ID: String
     var date: Date
-    var duration: Int
+    var introduction: Int
+    var main: Int
+    var conclusion: Int
     var topic: String
 
 }

--- a/Discussion-Korea/Discussion-Korea/DisscussionReservationScene/View/ReservationTableViewCell.swift
+++ b/Discussion-Korea/Discussion-Korea/DisscussionReservationScene/View/ReservationTableViewCell.swift
@@ -20,7 +20,7 @@ final class ReservationTableViewCell: UITableViewCell {
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.dateFormat = "yyyy년 M월 d일 H시 m분에 예약됨"
         self.dateLabel.text = "\(formatter.string(from: schedule.date))"
-        self.durationLabel.text = "\(schedule.duration)시간동안 진행"
+        self.durationLabel.text = "\(schedule.introduction + schedule.main + schedule.conclusion)분동안 진행"
         self.topicLabel.text = "주제: \(schedule.topic)"
         self.event = event
     }

--- a/Discussion-Korea/Discussion-Korea/Storyboard/Base.lproj/Main.storyboard
+++ b/Discussion-Korea/Discussion-Korea/Storyboard/Base.lproj/Main.storyboard
@@ -370,61 +370,119 @@
                                 <rect key="frame" x="20" y="76" width="374" height="746"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="mrp-U7-iuj">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="248.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="149"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="주제" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PdZ-5u-Zvv">
-                                                <rect key="frame" x="0.0" y="114" width="29.5" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="64.5" width="29.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="P6C-8E-CMb">
-                                                <rect key="frame" x="79.5" y="107.5" width="294.5" height="34"/>
+                                                <rect key="frame" x="79.5" y="57.5" width="294.5" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="fsp-hY-t4d">
-                                        <rect key="frame" x="0.0" y="248.5" width="374" height="249"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="xaJ-Q1-vcz">
+                                        <rect key="frame" x="0.0" y="149" width="374" height="149.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="진행 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bv1-qA-wvO">
-                                                <rect key="frame" x="0.0" y="114.5" width="93.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="입론 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IIy-Ui-B5i">
+                                                <rect key="frame" x="0.0" y="64.5" width="93.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C22-oJ-7E6">
+                                                <rect key="frame" x="93.5" y="64.5" width="93.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="분" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9SM-cv-xvh">
+                                                <rect key="frame" x="187" y="64.5" width="93.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minimumValue="1" maximumValue="15" translatesAutoresizingMaskIntoConstraints="NO" id="G8G-6K-d3l">
+                                                <rect key="frame" x="280.5" y="59" width="93.5" height="32"/>
+                                                <connections>
+                                                    <action selector="introStepperValueChanged:" destination="eMl-LJ-Nph" eventType="valueChanged" id="h89-ds-J2h"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="fsp-hY-t4d">
+                                        <rect key="frame" x="0.0" y="298.5" width="374" height="149"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="본론 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bv1-qA-wvO">
+                                                <rect key="frame" x="0.0" y="64.5" width="93.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fPC-yE-xys">
-                                                <rect key="frame" x="93.5" y="114.5" width="93.5" height="20.5"/>
+                                                <rect key="frame" x="93.5" y="64.5" width="93.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kYi-sz-JGc">
-                                                <rect key="frame" x="187" y="114.5" width="93.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="분" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kYi-sz-JGc">
+                                                <rect key="frame" x="187" y="64.5" width="93.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minimumValue="1" maximumValue="2" translatesAutoresizingMaskIntoConstraints="NO" id="Irf-3K-VpP">
-                                                <rect key="frame" x="280.5" y="108.5" width="93.5" height="32"/>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minimumValue="1" maximumValue="30" translatesAutoresizingMaskIntoConstraints="NO" id="Irf-3K-VpP">
+                                                <rect key="frame" x="280.5" y="58.5" width="93.5" height="32"/>
                                                 <connections>
-                                                    <action selector="stepperValueChanged:" destination="eMl-LJ-Nph" eventType="valueChanged" id="wue-ig-MI9"/>
+                                                    <action selector="mainStepperValueChanged:" destination="eMl-LJ-Nph" eventType="valueChanged" id="dVG-ow-3ft"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="GXE-IH-nBg">
+                                        <rect key="frame" x="0.0" y="447.5" width="374" height="149.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="결론 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MXo-qT-VfW">
+                                                <rect key="frame" x="0.0" y="64.5" width="93.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d2u-tM-8z5">
+                                                <rect key="frame" x="93.5" y="64.5" width="93.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="분" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pb6-5L-jZE">
+                                                <rect key="frame" x="187" y="64.5" width="93.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minimumValue="1" maximumValue="15" translatesAutoresizingMaskIntoConstraints="NO" id="2rH-i5-k8O">
+                                                <rect key="frame" x="280.5" y="58.5" width="93.5" height="32"/>
+                                                <connections>
+                                                    <action selector="conclusionStepperValueChanged:" destination="eMl-LJ-Nph" eventType="valueChanged" id="BDL-qs-UI7"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wz4-iw-CbR">
-                                        <rect key="frame" x="0.0" y="497.5" width="374" height="248.5"/>
+                                        <rect key="frame" x="0.0" y="597" width="374" height="149"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="시작 날짜" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IYT-kT-fmy">
-                                                <rect key="frame" x="0.0" y="0.0" width="63.5" height="248.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="63.5" height="149"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="ENf-4t-lQf">
-                                                <rect key="frame" x="64" y="0.0" width="310" height="249"/>
+                                                <rect key="frame" x="63.5" y="0.0" width="310.5" height="149"/>
                                             </datePicker>
                                         </subviews>
                                     </stackView>
@@ -448,8 +506,10 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="conclusionTimeLabel" destination="d2u-tM-8z5" id="WcH-QT-zPL"/>
                         <outlet property="datePicker" destination="ENf-4t-lQf" id="UU0-29-1zo"/>
-                        <outlet property="durationLabel" destination="fPC-yE-xys" id="HCL-Sb-Thy"/>
+                        <outlet property="introTimeLabel" destination="C22-oJ-7E6" id="GIo-sL-GfS"/>
+                        <outlet property="mainTimeLabel" destination="fPC-yE-xys" id="HCL-Sb-Thy"/>
                         <outlet property="submitButton" destination="2Wa-en-ZrT" id="f49-vz-rZ1"/>
                         <outlet property="topicTextField" destination="P6C-8E-CMb" id="uQl-Z6-ThC"/>
                     </connections>


### PR DESCRIPTION
**상세 작업**
- 토론을 예약할때 입론/자유토론/결론 시간을 각각 정할 수 있는 기능 추가

<img width="533" alt="image" src="https://user-images.githubusercontent.com/59321616/165056365-32f005fe-4c93-41a5-b4d1-082af878c87c.png">
