### PR TITLE
남은 시간과 스트리밍 변경 및 토론 페이즈 공지 추가

### DIFF
--- a/Discussion-Korea.xcodeproj/project.pbxproj
+++ b/Discussion-Korea.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		3FBDBC452886EAFF00A09BF4 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = 3FBDBC442886EAFF00A09BF4 /* RxTest */; };
 		3FBDBC472887E00B00A09BF4 /* LiveChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDBC462887E00B00A09BF4 /* LiveChatView.swift */; };
 		3FBDBC4928892F5700A09BF4 /* OpinionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDBC4828892F5700A09BF4 /* OpinionView.swift */; };
+		3FBDBC66288B301400A09BF4 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDBC65288B301400A09BF4 /* NoticeView.swift */; };
 		3FF62D9F282D93F1001F343C /* Side.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF62D9E282D93F1001F343C /* Side.swift */; };
 /* End PBXBuildFile section */
 
@@ -261,6 +262,7 @@
 		3FBDBC152886E3DF00A09BF4 /* DefaultSettingNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingNavigator.swift; sourceTree = "<group>"; };
 		3FBDBC462887E00B00A09BF4 /* LiveChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveChatView.swift; sourceTree = "<group>"; };
 		3FBDBC4828892F5700A09BF4 /* OpinionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpinionView.swift; sourceTree = "<group>"; };
+		3FBDBC65288B301400A09BF4 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		3FF62D9E282D93F1001F343C /* Side.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Side.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -447,6 +449,7 @@
 				3F37B3AA2820765900DB18B7 /* SerialOtherChatCell.swift */,
 				3F99EA3E287BD651000ACDA6 /* ChatPreview.swift */,
 				3FBDBC462887E00B00A09BF4 /* LiveChatView.swift */,
+				3FBDBC65288B301400A09BF4 /* NoticeView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -821,6 +824,7 @@
 				3F37B3C52820773600DB18B7 /* Chat.swift in Sources */,
 				3FB3579D282618A900F27C77 /* ScheduleCell.swift in Sources */,
 				3FB35786282406D200F27C77 /* ChatRoomSideMenuViewController.swift in Sources */,
+				3FBDBC66288B301400A09BF4 /* NoticeView.swift in Sources */,
 				3FBDBC122886E3A100A09BF4 /* DefaultEnterGuestNavigator.swift in Sources */,
 				3F95BC972843658D008DF2D2 /* SerialBotChatCell.swift in Sources */,
 				3F6696A42835BFDB0077E5B3 /* ChatRoomListViewModel.swift in Sources */,

--- a/Discussion-Korea.xcodeproj/project.pbxproj
+++ b/Discussion-Korea.xcodeproj/project.pbxproj
@@ -147,7 +147,7 @@
 		3FBDBC412886EAFF00A09BF4 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3FBDBC402886EAFF00A09BF4 /* RxCocoa */; };
 		3FBDBC432886EAFF00A09BF4 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3FBDBC422886EAFF00A09BF4 /* RxSwift */; };
 		3FBDBC452886EAFF00A09BF4 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = 3FBDBC442886EAFF00A09BF4 /* RxTest */; };
-		3FBDBC472887E00B00A09BF4 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDBC462887E00B00A09BF4 /* NoticeView.swift */; };
+		3FBDBC472887E00B00A09BF4 /* LiveChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDBC462887E00B00A09BF4 /* LiveChatView.swift */; };
 		3FBDBC4928892F5700A09BF4 /* OpinionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDBC4828892F5700A09BF4 /* OpinionView.swift */; };
 		3FF62D9F282D93F1001F343C /* Side.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF62D9E282D93F1001F343C /* Side.swift */; };
 /* End PBXBuildFile section */
@@ -259,7 +259,7 @@
 		3FBDBC112886E3A100A09BF4 /* DefaultEnterGuestNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEnterGuestNavigator.swift; sourceTree = "<group>"; };
 		3FBDBC132886E3CB00A09BF4 /* DefaultHomeNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHomeNavigator.swift; sourceTree = "<group>"; };
 		3FBDBC152886E3DF00A09BF4 /* DefaultSettingNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingNavigator.swift; sourceTree = "<group>"; };
-		3FBDBC462887E00B00A09BF4 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
+		3FBDBC462887E00B00A09BF4 /* LiveChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveChatView.swift; sourceTree = "<group>"; };
 		3FBDBC4828892F5700A09BF4 /* OpinionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpinionView.swift; sourceTree = "<group>"; };
 		3FF62D9E282D93F1001F343C /* Side.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Side.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -446,7 +446,7 @@
 				3F95BC962843658D008DF2D2 /* SerialBotChatCell.swift */,
 				3F37B3AA2820765900DB18B7 /* SerialOtherChatCell.swift */,
 				3F99EA3E287BD651000ACDA6 /* ChatPreview.swift */,
-				3FBDBC462887E00B00A09BF4 /* NoticeView.swift */,
+				3FBDBC462887E00B00A09BF4 /* LiveChatView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -783,7 +783,7 @@
 				3FBDBC082886E28300A09BF4 /* DefaultAddDiscussionNavigator.swift in Sources */,
 				3F910435283FB29200446239 /* EnterGuestNavigator.swift in Sources */,
 				3F37B3CB2820773C00DB18B7 /* UserInfoUsecase.swift in Sources */,
-				3FBDBC472887E00B00A09BF4 /* NoticeView.swift in Sources */,
+				3FBDBC472887E00B00A09BF4 /* LiveChatView.swift in Sources */,
 				3F910432283F6F5600446239 /* AddChatRoomViewController.swift in Sources */,
 				3F37B3B52820766400DB18B7 /* HomeViewModel.swift in Sources */,
 				3FB357A328261A7400F27C77 /* DiscussionUsecase.swift in Sources */,

--- a/Discussion-Korea/Presentation/Scenes/ChatRoom/ChatRoomViewController.swift
+++ b/Discussion-Korea/Presentation/Scenes/ChatRoom/ChatRoomViewController.swift
@@ -85,10 +85,6 @@ final class ChatRoomViewController: UIViewController {
         sendButton.setBackgroundImage(UIImage(systemName: "paperplane.fill"), for: .normal)
         sendButton.setBackgroundImage(UIImage(systemName: "paperplane"), for: .disabled)
         sendButton.tintColor = UIColor.accentColor
-        // TODO: 보내기버튼 둥글게 적용하기
-//        sendButton.layer.borderColor = UIColor.primaryColor?.cgColor
-//        sendButton.layer.borderWidth = 1.0
-//        sendButton.layer.cornerRadius = 13
         sendButton.isEnabled = false
         sendButton.accessibilityLabel = "채팅 보내기"
         return sendButton
@@ -141,7 +137,6 @@ final class ChatRoomViewController: UIViewController {
             make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(10)
             make.trailing.equalTo(self.view.safeAreaLayoutGuide).offset(-10)
             make.bottom.equalTo(self.messageCollectionView.snp.bottom).offset(-10)
-//            make.height.equalTo(30)
         }
         inputBackground.snp.makeConstraints { make in
             make.leading.equalToSuperview()

--- a/Discussion-Korea/Presentation/Scenes/ChatRoom/ChatRoomViewController.swift
+++ b/Discussion-Korea/Presentation/Scenes/ChatRoom/ChatRoomViewController.swift
@@ -36,6 +36,7 @@ final class ChatRoomViewController: UIViewController {
         return button
     }()
 
+    private let noticeView = NoticeView()
     private let liveChatView = LiveChatView()
     private let chatPreview = ChatPreview()
 
@@ -120,11 +121,17 @@ final class ChatRoomViewController: UIViewController {
         self.view.addSubview(self.sendButton)
         self.view.addSubview(self.chatPreview)
         self.view.addSubview(self.messageTextView)
+        self.view.addSubview(self.noticeView)
         self.navigationItem.rightBarButtonItems = [self.menuButton, self.time]
-        self.liveChatView.snp.makeConstraints { make in
+        self.noticeView.snp.makeConstraints { make in
             make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(5)
             make.trailing.equalTo(self.view.safeAreaLayoutGuide).offset(-5)
             make.top.equalTo(self.view.safeAreaLayoutGuide)
+        }
+        self.liveChatView.snp.makeConstraints { make in
+            make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(5)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide).offset(-5)
+            make.top.equalTo(self.noticeView.snp.bottom).offset(5)
         }
         self.messageCollectionView.dataSource = self
         self.messageCollectionView.snp.makeConstraints { make in
@@ -202,7 +209,11 @@ final class ChatRoomViewController: UIViewController {
         )
         let output = self.viewModel.transform(input: input)
 
-        output.remainTime.drive(self.time.rx.title).disposed(by: self.disposeBag)
+        output.remainTime.drive(self.noticeView.rx.remainTime)
+            .disposed(by: self.disposeBag)
+
+        output.noticeContent.drive(self.noticeView.rx.content)
+            .disposed(by: self.disposeBag)
 
         output.chatItems
             .withLatestFrom(bottomScrolled) { ($0, $1) }

--- a/Discussion-Korea/Presentation/Scenes/ChatRoom/ChatRoomViewController.swift
+++ b/Discussion-Korea/Presentation/Scenes/ChatRoom/ChatRoomViewController.swift
@@ -36,7 +36,7 @@ final class ChatRoomViewController: UIViewController {
         return button
     }()
 
-    private let noticeView = NoticeView()
+    private let liveChatView = LiveChatView()
     private let chatPreview = ChatPreview()
 
     private let messageCollectionView: UICollectionView = {
@@ -117,7 +117,7 @@ final class ChatRoomViewController: UIViewController {
 
     private func setSubViews() {
         self.view.addSubview(self.messageCollectionView)
-        self.view.addSubview(self.noticeView)
+        self.view.addSubview(self.liveChatView)
         let inputBackground = UIView()
         inputBackground.backgroundColor = .systemBackground
         self.view.addSubview(inputBackground)
@@ -125,7 +125,7 @@ final class ChatRoomViewController: UIViewController {
         self.view.addSubview(self.chatPreview)
         self.view.addSubview(self.messageTextView)
         self.navigationItem.rightBarButtonItems = [self.menuButton, self.time]
-        self.noticeView.snp.makeConstraints { make in
+        self.liveChatView.snp.makeConstraints { make in
             make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(5)
             make.trailing.equalTo(self.view.safeAreaLayoutGuide).offset(-5)
             make.top.equalTo(self.view.safeAreaLayoutGuide)
@@ -241,9 +241,8 @@ final class ChatRoomViewController: UIViewController {
             .drive(self.chatPreview.rx.isHidden)
             .disposed(by: self.disposeBag)
 
-        output.realTimeChat.drive { [unowned self] in
-            self.noticeView.bind(with: $0)
-        }.disposed(by: self.disposeBag)
+        output.realTimeChat.drive(self.liveChatView.rx.chatViewModel)
+            .disposed(by: self.disposeBag)
 
         output.sendEnable.drive(self.sendButton.rx.isEnabled)
             .disposed(by: self.disposeBag)

--- a/Discussion-Korea/Presentation/Scenes/ChatRoom/ChatRoomViewModel.swift
+++ b/Discussion-Korea/Presentation/Scenes/ChatRoom/ChatRoomViewModel.swift
@@ -218,6 +218,38 @@ final class ChatRoomViewModel: ViewModelType {
                 }
             }
 
+        let noticeContent = status.map { status -> String in
+            // TODO: 하드코딩 고치기
+            switch status {
+            case 2:
+                return "찬성측의 입론 시간"
+            case 3:
+                return "반대측의 입론 시간"
+            case 4:
+                return "자유토론 시간"
+            case 5:
+                return "찬성측의 결론 시간"
+            case 6:
+                return "반대측의 결론 시간"
+            case 7:
+                return "쉬는 시간"
+            case 8:
+                return "반대측의 입론 시간"
+            case 9:
+                return "찬성측의 입론 시간"
+            case 10:
+                return "자유토론 시간"
+            case 11:
+                return "반대측의 결론 시간"
+            case 12:
+                return "찬성측의 결론 시간"
+            case 13:
+                return "투표 시간"
+            default:
+                return ""
+            }
+        }
+
         let canSend = Driver.combineLatest(canEditable, input.content) {
             return $0 && !$1.isEmpty
         }
@@ -294,6 +326,7 @@ final class ChatRoomViewModel: ViewModelType {
 
         return Output(
             remainTime: remainTime,
+            noticeContent: noticeContent,
             chatItems: chatItems,
             mask: masking,
             toBottom: input.previewTouched,
@@ -322,6 +355,7 @@ extension ChatRoomViewModel {
 
     struct Output {
         let remainTime: Driver<String>
+        let noticeContent: Driver<String>
         let chatItems: Driver<ChatItemViewModel>
         let mask: Driver<String>
         let toBottom: Driver<Void>

--- a/Discussion-Korea/Presentation/Scenes/ChatRoom/View/LiveChatView.swift
+++ b/Discussion-Korea/Presentation/Scenes/ChatRoom/View/LiveChatView.swift
@@ -7,21 +7,13 @@
 
 import SnapKit
 import UIKit
+import RxSwift
 
-final class NoticeView: UIView {
+final class LiveChatView: UIView {
 
     // MARK: properties
 
-    private let profileImageView: UIImageView = {
-        let imageView = UIImageView(image: UIImage(systemName: "person.fill"))
-        imageView.tintColor = UIColor.white
-        imageView.backgroundColor = .accentColor
-        imageView.layer.cornerRadius = 6
-        imageView.layer.masksToBounds = true
-        return imageView
-    }()
-
-    private let descriptionLabel: UILabel = {
+    fileprivate let descriptionLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 12.0)
         label.textColor = .systemGray
@@ -29,7 +21,7 @@ final class NoticeView: UIView {
         return label
     }()
 
-    private let label: UILabel = {
+    fileprivate let label: UILabel = {
         let label = PaddingLabel(padding: UIEdgeInsets(
             top: 12.0, left: 20.0, bottom: 12.0, right: 20.0)
         )
@@ -58,17 +50,11 @@ final class NoticeView: UIView {
     private func setSubviews() {
         self.isHidden = true
         self.backgroundColor = .systemBackground
-        self.addSubview(self.profileImageView)
         self.addSubview(self.descriptionLabel)
         self.addSubview(self.label)
-        self.profileImageView.snp.makeConstraints { make in
-            make.width.height.equalTo(35)
-            make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(10)
-        }
         self.descriptionLabel.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            make.top.equalTo(self.profileImageView.snp.bottom).offset(10)
+            make.top.equalToSuperview().offset(10)
         }
         self.label.snp.makeConstraints { make in
             make.leading.trailing.bottom.equalToSuperview()
@@ -76,18 +62,17 @@ final class NoticeView: UIView {
         }
     }
 
-    // MARK: - methods
+}
 
-    func bind(with viewModel: ChatItemViewModel) {
-        self.isHidden = viewModel.content.isEmpty
-        if let image = viewModel.image {
-            self.profileImageView.image = image
-        } else if let url = viewModel.url {
-            self.profileImageView.setImage(url)
+extension Reactive where Base: LiveChatView {
+
+    var chatViewModel: Binder<ChatItemViewModel> {
+        return Binder(self.base) { liveChatView, viewModel in
+            liveChatView.isHidden = viewModel.content.isEmpty
+            liveChatView.descriptionLabel.text = "\(viewModel.nickname)님이 작성중입니다..."
+            liveChatView.label.text = viewModel.content
+            liveChatView.backgroundColor = viewModel.backgroundColor
         }
-        self.descriptionLabel.text = "\(viewModel.nickname)님이 작성중입니다..."
-        self.label.text = viewModel.content
-        self.backgroundColor = viewModel.backgroundColor
     }
 
 }

--- a/Discussion-Korea/Presentation/Scenes/ChatRoom/View/NoticeView.swift
+++ b/Discussion-Korea/Presentation/Scenes/ChatRoom/View/NoticeView.swift
@@ -1,0 +1,85 @@
+//
+//  NoticeView.swift
+//  Discussion-Korea
+//
+//  Created by 이청수 on 2022/07/23.
+//
+
+import UIKit
+import RxSwift
+
+final class NoticeView: UIView {
+
+    // MARK: properties
+
+    fileprivate let iconImageView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(systemName: "megaphone.fill"))
+        imageView.tintColor = UIColor.label
+        return imageView
+    }()
+
+    fileprivate let contentLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 16.0)
+        return label
+    }()
+
+    fileprivate let remainTimeLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14.0)
+        return label
+    }()
+
+    // MARK: - init/deinit
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.setSubviews()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setSubviews()
+    }
+
+    private func setSubviews() {
+        self.layer.cornerRadius = 5.0
+        self.backgroundColor = UIColor.systemBackground
+        self.addSubview(self.iconImageView)
+        self.addSubview(self.contentLabel)
+        self.addSubview(self.remainTimeLabel)
+        self.iconImageView.snp.makeConstraints { make in
+            make.leading.top.equalToSuperview().offset(10)
+            make.bottom.lessThanOrEqualToSuperview().offset(-10)
+            make.size.equalTo(30)
+        }
+        self.contentLabel.snp.makeConstraints { make in
+            make.leading.equalTo(self.iconImageView.snp.trailing).offset(10)
+            make.top.equalTo(self.iconImageView)
+            make.trailing.equalToSuperview()
+        }
+        self.remainTimeLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.contentLabel.snp.bottom).offset(3)
+            make.leading.trailing.equalTo(self.contentLabel)
+            make.bottom.equalToSuperview().offset(-10)
+        }
+    }
+
+}
+
+extension Reactive where Base: NoticeView {
+
+    var content: Binder<String> {
+        return Binder(self.base) { noticeView, content in
+            noticeView.isHidden = content.isEmpty
+            noticeView.contentLabel.text = content
+        }
+    }
+
+    var remainTime: Binder<String> {
+        return Binder(self.base) { noticeView, timeString in
+            noticeView.remainTimeLabel.text = timeString
+        }
+    }
+
+}


### PR DESCRIPTION
# 상세작업

## 채팅방
<img width="40%" alt="image" src="https://user-images.githubusercontent.com/59321616/180617619-31bb84e8-dc48-4d2e-a27f-1c6ef3e9ca20.png"> <img width="40%" alt="image" src="https://user-images.githubusercontent.com/59321616/180617628-2a98d677-7c4f-49eb-b860-a3b3ce26fb52.png">

- 토론 페이즈에 맞는 공지사항 내용
- 공지사항에 남은 시간을 함께 표시
- 실시간 채팅 스트리밍은 공지사항 뷰 밑에 위치하도록 변경